### PR TITLE
Null Simplification and Reference Type Node Unit Tests

### DIFF
--- a/SimpleDirectedGraph/Digraph.cs
+++ b/SimpleDirectedGraph/Digraph.cs
@@ -40,9 +40,7 @@ namespace Bluspur.Graphs
         /// </summary>
         public virtual void AddEdge(TEdge edge)
         {
-            // TODO: Implement Exception handling for when either the Origin or Destination of an Edge is false.
-            // TODO: Implement Exception handling for when the Origin and Destination of an Edge are the same.
-            if (edge is null) throw new ArgumentNullException(nameof(edge));
+            CheckEdgeForNullValues(edge);
             // Check if an adjacency list already exists for the Origin.
             _adjacencyLists.TryGetValue(edge.Origin, out var outgoingEdges);
             // If the list exists, then just append the new edge.
@@ -58,6 +56,8 @@ namespace Bluspur.Graphs
             if (!_adjacencyLists.ContainsKey(edge.Destination))
                 AddNode(edge.Destination);
         }
+
+        
 
         /// <summary>
         /// Removes a node object from the graph and any related edges.
@@ -80,9 +80,9 @@ namespace Bluspur.Graphs
         /// <summary>
         /// Removes an Edge from the graph based on its Origin and Destination properties.
         /// </summary>
-        public virtual void TryRemoveEdge(IEdge<TNode> edge)
+        public virtual void TryRemoveEdge(TEdge edge)
         {
-            if (edge is null) throw new ArgumentNullException(nameof(edge));
+            CheckEdgeForNullValues(edge);
             _adjacencyLists.TryGetValue(edge.Origin, out var outgoingEdges);
             if (outgoingEdges is not null)
             {
@@ -131,6 +131,16 @@ namespace Bluspur.Graphs
                 yield break;
             foreach (TEdge edge in outgoingEdges)
                 yield return edge;
+        }
+
+        /// <summary>
+        /// Takes an edge and checks that it and it's essential properties are NOT null. If they are throw an exception.
+        /// </summary>
+        protected virtual void CheckEdgeForNullValues(TEdge edge)
+        {
+            if (edge is null) throw new ArgumentNullException(nameof(edge));
+            if (edge.Origin is null) throw new ArgumentException($"{nameof(edge.Origin)} must not be Null");
+            if (edge.Destination is null) throw new ArgumentException($"{nameof(edge.Destination)} must not be Null");
         }
     }
 }

--- a/SimpleDirectedGraph/Digraph.cs
+++ b/SimpleDirectedGraph/Digraph.cs
@@ -57,8 +57,6 @@ namespace Bluspur.Graphs
                 AddNode(edge.Destination);
         }
 
-        
-
         /// <summary>
         /// Removes a node object from the graph and any related edges.
         /// </summary>

--- a/SimpleDirectedGraph/Digraph.cs
+++ b/SimpleDirectedGraph/Digraph.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Bluspur.Graphs
 {
@@ -8,7 +9,7 @@ namespace Bluspur.Graphs
     /// </summary>
     /// <typeparam name="TNode">Generic type to be used as the graph nodes.</typeparam>
     /// <typeparam name="TEdge">Generic type that represents an edge in the graph. Must inherit from IEdge.</typeparam>
-    public class Digraph<TNode, TEdge> where TNode : notnull where TEdge : IEdge<TNode>
+    public class Digraph<TNode, TEdge> where TEdge : IEdge<TNode>
     {
         private Dictionary<TNode, List<TEdge>> _adjacencyLists = new();
 
@@ -22,19 +23,7 @@ namespace Bluspur.Graphs
         /// Returns a count of all edges from all nodes in the graph.
         /// </summary>
         public int EdgeCount
-        {
-            get
-            {
-                int count = 0;
-
-                foreach (KeyValuePair<TNode, List<TEdge>> kvp in _adjacencyLists)
-                {
-                    count += kvp.Value.Count;
-                }
-
-                return count;
-            }
-        }
+            => _adjacencyLists.Values.Sum(x => x.Count);
 
         /// <summary>
         /// Adds a Node with no outgoing edges.
@@ -122,15 +111,7 @@ namespace Bluspur.Graphs
             if (origin is null) throw new ArgumentNullException(nameof(origin));
             if (destination is null) throw new ArgumentNullException(nameof(destination));
             _adjacencyLists.TryGetValue(origin, out var outgoingEdges);
-            if (outgoingEdges is not null)
-            {
-                foreach (var edge in outgoingEdges)
-                {
-                    if (edge.Destination.Equals(destination))
-                        return true;
-                }
-            }
-            return false;
+            return outgoingEdges?.Any(edge => edge.Destination.Equals(destination)) ?? false;
         }
 
         /// <summary>

--- a/SimpleDirectedGraph/IEdge.cs
+++ b/SimpleDirectedGraph/IEdge.cs
@@ -7,7 +7,7 @@
     public interface IEdge<TNode>
     {
         /// <summary>
-        /// The Node from which an starts.
+        /// The Node from which an edge starts.
         /// </summary>
         public TNode Origin { get; }
         /// <summary>

--- a/SimpleDirectedGraphTests/DigraphReferenceNodeTests.cs
+++ b/SimpleDirectedGraphTests/DigraphReferenceNodeTests.cs
@@ -1,0 +1,197 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace Bluspur.Graphs.Tests
+{
+    /// <summary>
+    /// Tests Digraph methods when using a reference type as Node type.
+    /// </summary>
+    [TestClass]
+    public class DigraphReferenceNodeTests
+    {
+        [TestMethod()]
+        public void AddEdge_ShouldThrowExceptionWhenEdgeIsNull()
+        {
+            ReferenceNode originNode = new("origin", 0);
+            ReferenceNode destinationNode = null;
+            Edge edge = new(originNode, destinationNode);
+            Digraph<ReferenceNode, Edge> graph = new();
+
+            Assert.ThrowsException<ArgumentException>(() => graph.AddEdge(edge));
+        }
+
+        [TestMethod()]
+        public void AddEdge_ShouldThrowExceptionWhenEdgePropertyIsNull()
+        {
+            Edge edge = null;
+            Digraph<ReferenceNode, Edge> graph = new();
+
+            Assert.ThrowsException<ArgumentNullException>(() => graph.AddEdge(edge));
+        }
+
+        [TestMethod()]
+        public void AddEdgeTest()
+        {
+            ReferenceNode originNode = new("origin", 0);
+            ReferenceNode destinationNode = new("destination", 1);
+            Edge edge = new(originNode, destinationNode);
+            Digraph<ReferenceNode, Edge> digraph = new();
+            digraph.AddEdge(edge);
+            Assert.IsTrue(digraph.ContainsEdge(originNode, destinationNode));
+        }
+
+        [TestMethod()]
+        public void AddNodeTest_ShouldThrowExceptionWhenNodeIsNull()
+        {
+            ReferenceNode nullNode = null;
+            Digraph<ReferenceNode, Edge> graph = new();
+            Assert.ThrowsException<ArgumentNullException>(() => graph.AddNode(nullNode));
+        }
+
+        [TestMethod()]
+        public void AddNodeTest()
+        {
+            ReferenceNode newNode = new("newNode", 0);
+            Digraph<ReferenceNode, Edge> graph = new();
+
+            graph.AddNode(newNode);
+
+            Assert.IsTrue(graph.ContainsNode(newNode));
+        }
+
+        [TestMethod()]
+        public void GetNodesTest()
+        {
+            ReferenceNode nodeOne = new("nodeOne", 0);
+            ReferenceNode nodeTwo = new("nodeTwo", 1);
+            ReferenceNode nodeThree = new("nodeThree", 2);
+            Digraph<ReferenceNode, Edge> digraph = new();
+            digraph.AddNode(nodeOne);
+            digraph.AddNode(nodeTwo);
+            digraph.AddNode(nodeThree);
+
+            var nodes = digraph.GetNodes().ToList();
+
+            CollectionAssert.Contains(nodes, nodeOne);
+            CollectionAssert.Contains(nodes, nodeTwo);
+            CollectionAssert.Contains(nodes, nodeThree);
+        }
+
+        [TestMethod()]
+        public void GetOutgoingEdgesTest()
+        {
+            ReferenceNode nodeOne = new("nodeOne", 0);
+            ReferenceNode nodeTwo = new("nodeTwo", 1);
+            ReferenceNode nodeThree = new("nodeThree", 2);
+            ReferenceNode nodeFour = new("nodeFour", 3);
+            Edge edgeOne = new(nodeOne, nodeTwo);
+            Edge edgeTwo = new(nodeOne, nodeThree);
+            Edge edgeThree = new(nodeOne, nodeFour);
+            Digraph<ReferenceNode, Edge> digraph = new();
+            digraph.AddEdge(edgeOne);
+            digraph.AddEdge(edgeTwo);
+            digraph.AddEdge(edgeThree);
+
+            var edges = digraph.GetOutgoingEdges(nodeOne).ToList();
+
+            CollectionAssert.Contains(edges, edgeOne);
+            CollectionAssert.Contains(edges, edgeTwo);
+            CollectionAssert.Contains(edges, edgeThree);
+        }
+
+        [TestMethod()]
+        public void TryRemoveEdgeTest_ShouldThrowExceptionWhenEdgeIsNull()
+        {
+            Edge edge = null;
+            Digraph<ReferenceNode, Edge> graph = new();
+
+            Assert.ThrowsException<ArgumentNullException>(() => graph.TryRemoveEdge(edge));
+        }
+
+        [TestMethod()]
+        public void TryRemoveEdgeTest_ShouldThrowExceptionWhenEdgePropertyIsNull()
+        {
+            ReferenceNode originNode = new("origin", 0);
+            ReferenceNode destinationNode = null;
+            Edge edge = new(originNode, destinationNode);
+            Digraph<ReferenceNode, Edge> graph = new();
+
+            Assert.ThrowsException<ArgumentException>(() => graph.TryRemoveEdge(edge));
+        }
+
+        [TestMethod()]
+        public void TryRemoveEdgeTest()
+        {
+            ReferenceNode nodeOne = new("nodeOne", 0);
+            ReferenceNode nodeTwo = new("nodeTwo", 1);
+            Edge edge = new(nodeOne, nodeTwo);
+            Digraph<ReferenceNode, Edge> digraph = new();
+            digraph.AddEdge(edge);
+
+            digraph.TryRemoveEdge(edge);
+
+            var outgoingEdges = digraph.GetOutgoingEdges(nodeOne).ToList();
+            CollectionAssert.DoesNotContain(outgoingEdges, edge);
+        }
+
+        [TestMethod()]
+        public void TryRemoveNodeTest_ShouldThrowExceptionWhenNodeIsNull()
+        {
+            ReferenceNode nullNode = null;
+            Digraph<ReferenceNode, Edge> graph = new();
+            Assert.ThrowsException<ArgumentNullException>(() => graph.TryRemoveNode(nullNode));
+        }
+
+        [TestMethod()]
+        public void TryRemoveNodeTest()
+        {
+            ReferenceNode nodeOne = new("nodeOne", 0);
+            Digraph<ReferenceNode, Edge> digraph = new();
+            digraph.AddNode(nodeOne);
+
+            digraph.TryRemoveNode(nodeOne);
+
+            Assert.IsFalse(digraph.ContainsNode(nodeOne));
+        }
+
+        [TestMethod()]
+        public void ContainsEdgeTest()
+        {
+            ReferenceNode nodeOne = new("nodeOne", 0);
+            ReferenceNode nodeTwo = new("nodeTwo", 1);
+            Edge edge = new(nodeOne, nodeTwo);
+            Digraph<ReferenceNode, Edge> digraph = new();
+            digraph.AddEdge(edge);
+
+            Assert.IsTrue(digraph.ContainsEdge(nodeOne, nodeTwo));
+        }
+
+        public class Edge : IEdge<ReferenceNode>
+        {
+            private ReferenceNode origin, destination;
+
+            public ReferenceNode Origin => origin;
+
+            public ReferenceNode Destination => destination;
+
+            public Edge(ReferenceNode origin, ReferenceNode destination)
+            {
+                this.origin = origin;
+                this.destination = destination;
+            }
+        }
+
+        public class ReferenceNode
+        {
+            public string Name { get; }
+            public int Number { get; }
+
+            public ReferenceNode(string name, int number)
+            {
+                Name = name;
+                Number = number;
+            }
+        }
+    }
+}

--- a/SimpleDirectedGraphTests/DigraphValueNodeTests.cs
+++ b/SimpleDirectedGraphTests/DigraphValueNodeTests.cs
@@ -3,8 +3,11 @@ using System.Linq;
 
 namespace Bluspur.Graphs.Tests
 {
+    /// <summary>
+    /// Tests Digraph methods when using a value type (int) as the node type
+    /// </summary>
     [TestClass]
-    public class DigraphTests
+    public class DigraphValueNodeTests
     {
         [TestMethod()]
         public void AddEdgeTest()

--- a/SimpleDirectedGraphTests/DigraphValueNodeTests.cs
+++ b/SimpleDirectedGraphTests/DigraphValueNodeTests.cs
@@ -116,6 +116,5 @@ namespace Bluspur.Graphs.Tests
                 this.destination = destination;
             }
         }
-
     }
 }


### PR DESCRIPTION
Removed requirement for "notnull" from TNode. Reworked null checking throughout. Added new unit tests for when digraph uses a TNode that is a reference type.